### PR TITLE
Update getXPValue to avoid overflow

### DIFF
--- a/src/main/java/cofh/core/common/event/EffectEvents.java
+++ b/src/main/java/cofh/core/common/event/EffectEvents.java
@@ -184,10 +184,10 @@ public class EffectEvents {
     // region HELPERS
     private static int getXPValue(int baseExp, int amplifier) {
 
-        return baseExp * (100 + CLARITY_MOD * (1 + amplifier)) / 100;
+        return (int) ((double) baseExp * (1.0D + CLARITY_MOD * (1 + amplifier)));
     }
     // endregion
 
-    private static final int CLARITY_MOD = 20;
+    private static final int CLARITY_MOD = 0.2D;
 
 }


### PR DESCRIPTION
getXPValue currently multiplies baseExp by over 100 before dividing it at the end.  
This intermediate value is prone to overflows on large baseExp values and can lead to losing xp.
```java
private static int getXPValue(int baseExp, int amplifier) {

   return baseExp * (100 + CLARITY_MOD * (1 + amplifier)) / 100;
}
 ```
 Using floating point calculations instead sacrifices some precision but prevents overflows, instead saturating at `Double.POSITIVE_INFINITY`, which gets cast to `int` as `Integer.MAX_VALUE` (2147483647) - thus avoiding the overflow.